### PR TITLE
Add CommonDraftWriter and Draft response scheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^19.0.0",
         "slate": "^0.112.0",
         "slate-react": "^0.112.1",
-        "uuid": "^11.0.5"
+        "uuid": "^11.0.5",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5194,6 +5195,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.0.0",
     "slate": "^0.112.0",
     "slate-react": "^0.112.1",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/_components/DraftEditor.tsx
+++ b/src/app/_components/DraftEditor.tsx
@@ -141,6 +141,6 @@ function DraftElementHeading(props: RenderElementProps): JSX.Element {
     case 6:
       return <h6 className={styles.heading} {...props.attributes}>{props.children}</h6>;
     default:
-      return <></>;
+      return <h6 className={styles.heading} {...props.attributes}>{props.children}</h6>;
   }
 }

--- a/src/app/_components/DraftEditorPopup.tsx
+++ b/src/app/_components/DraftEditorPopup.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { CSSProperties, JSX, ReactNode, useEffect, useState } from "react"
 import { useDraftContext } from "./DraftContext";
 

--- a/src/app/_types/Draft.ts
+++ b/src/app/_types/Draft.ts
@@ -1,11 +1,15 @@
 import { Editor, Selection, Text, Transforms, Range } from "slate"
 import { ReactEditor } from "slate-react";
 
+////////////////////////////////////////
+// Draft
+// NOTE: If you touch this definition, maybe you should also touch ./DraftResponseFormat.ts
+
 export type Draft = (DraftElement | DraftText)[];
 
 export type DraftElement =
   { type: 'paragraph', children: DraftText[] } |
-  { type: 'heading', level: 1 | 2 | 3 | 4 | 5 | 6, children: DraftText[] }
+  { type: 'heading', level: number, children: DraftText[] }
 ;
 
 export type DraftText =
@@ -13,6 +17,8 @@ export type DraftText =
   { text: string, selected: true, ids?: string[] } |
   { text: string, suggested: true, suggestion: string }
 ;
+
+////////////////////////////////////////
 
 export type DraftSelection = Selection;
 

--- a/src/app/_types/DraftResponseFormat.ts
+++ b/src/app/_types/DraftResponseFormat.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { zodResponseFormat } from "openai/helpers/zod";
+
+const PlainTextScheme = z.object({
+  type: z.literal("plain_text"),
+  text: z.string(),
+}).required();
+
+const SelectedTextScheme = z.object({
+  type: z.literal("selected_text"),
+  text: z.string(),
+  selected: z.literal(true),
+  ids: z.array(z.string()),
+}).required({
+  type: true,
+  text: true,
+  selected: true,
+});
+
+const SuggestedTextScheme = z.object({
+  type: z.literal("suggested_text"),
+  text: z.string(),
+  suggested: z.literal(true),
+  suggestion: z.string(),
+}).required();
+
+const DraftTextScheme = z.union([
+  PlainTextScheme,
+  SelectedTextScheme,
+  SuggestedTextScheme
+]);
+
+const ParagraphElementScheme = z.object({
+  type: z.literal("paragraph"),
+  children: z.array(DraftTextScheme),
+}).required();
+
+const HeadingElementScheme = z.object({
+  type: z.literal("heading"),
+  level: z.number().int(),
+  children: z.array(DraftTextScheme),
+}).required();
+
+const DraftElementScheme = z.union([
+  ParagraphElementScheme,
+  HeadingElementScheme
+]);
+
+const DraftScheme = z.object({draft: z.array(DraftElementScheme)});
+
+export const OpenAIDraftResponseFormat = zodResponseFormat(DraftScheme, "draft_response");

--- a/src/app/api/_agent/CommonDraftWriter.ts
+++ b/src/app/api/_agent/CommonDraftWriter.ts
@@ -1,0 +1,46 @@
+'use server';
+import { Draft } from "@/types/Draft";
+import { OpenAIDraftResponseFormat } from "@/types/DraftResponseFormat";
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  apiKey: process.env["OPENAI_API_KEY"],
+});
+
+export default async function CommonDraftWriterAction(prevDraft: Draft, request: string): Promise<Draft> {
+  try {
+    const completion = await openai.beta.chat.completions.parse({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: `
+# 命令
+あなたはユーザーの提供する情報に基づいて、法律に関係する文書を作成するエージェントである。
+以下の情報をもとに、法律に関係する文書のドラフトを作成せよ。
+# 出力フォーマット
+ドラフトは、段落 paragraph と見出し heading を有効活用し、成形された形で出力せよ。
+`
+          + (prevDraft.length !== 0) ? `
+# 既存のドラフト
+ユーザーが事前に用意したドラフトは以下の通りである。参考にせよ。
+${JSON.stringify(prevDraft)}
+` : ""
+        },
+        { role: "user", content: request },
+      ],
+      response_format: OpenAIDraftResponseFormat,
+    });
+    const plainDraftResponse = completion.choices[0]?.message;
+    console.log(completion.choices[0].message);
+
+    if (plainDraftResponse.refusal) {
+      console.error("OpenAI API Error:", plainDraftResponse.refusal);
+      return prevDraft;
+    }
+    
+    return plainDraftResponse.parsed?.draft ?? prevDraft;
+
+  } catch (error) {
+    console.error("OpenAI API Error:", error);
+    return prevDraft;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <h2>HOME</h2>
       <Link href="/doc-editor"> ドキュメントエディタへ </Link>
       <br />
-      <Link href="/sample"> Next.js サンプルページへ </Link>
+      <Link href="/sample"> サンプルページへ </Link>
       <br />
       <Link href="/interaction">インタラクションのテスト</Link> 
 

--- a/src/app/sample/SampleCommonDraftWriter.tsx
+++ b/src/app/sample/SampleCommonDraftWriter.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import React, { startTransition, useActionState } from "react";
+import CommonDraftWriterAction from "@/api/_agent/CommonDraftWriter";
+import { useDraftAccessorContext } from "@/components/DraftContext";
+import DraftEditor from "@/components/DraftEditor";
+
+export default function SampleCommonDraftWriter(): React.ReactElement {
+  const draftAccessor = useDraftAccessorContext();
+  const [draft, action, isPending] = useActionState(CommonDraftWriterAction, []);
+  const [prevDraft, setPrevDraft] = React.useState(draft);
+
+  const [request, setRequest] = React.useState("");
+
+  async function handleRequest() {
+    startTransition(async () => {
+      await action(request);
+    });
+  }
+
+  if (draft !== prevDraft) {
+    setPrevDraft(draft);
+    draftAccessor.replaceDraft(draft);
+  }
+  
+  return (
+    <div>
+      <DraftEditor />
+      <textarea value={request} onChange={(e) => setRequest(e.target.value)} />
+      <button onClick={handleRequest} disabled={isPending}>Request</button>
+    </div>
+  )
+}

--- a/src/app/sample/SampleDraftEditor.tsx
+++ b/src/app/sample/SampleDraftEditor.tsx
@@ -6,6 +6,7 @@ import DraftEditor from "../_components/DraftEditor";
 import { DraftEditorFocusedRangePopup } from "../_components/DraftEditorPopup";
 import { useDraftAccessorContext } from "../_components/DraftContext";
 
+
 export default function SampleDraftEditor(): React.ReactElement {
   const draftAccessor = useDraftAccessorContext();
 

--- a/src/app/sample/page.tsx
+++ b/src/app/sample/page.tsx
@@ -1,6 +1,7 @@
 import { DraftContext } from "../_components/DraftContext";
 import SampleCallingRouteHandler from "./SampleCallingRouteHandler";
 import SampleCallingServerAction from "./SampleCallingServerAction";
+import SampleCommonDraftWriter from "./SampleCommonDraftWriter";
 import SampleDraftEditor from "./SampleDraftEditor";
 
 // NEXT.js では、page.tsx というファイル名のファイルを定義するだけで、URL に対応するページが作成される。
@@ -20,6 +21,10 @@ export default function SamplePage() {
       <DraftContext>
         <h3>Rich Editor Sample</h3>
         <SampleDraftEditor />
+      </DraftContext>
+      <DraftContext>
+        <h3>CommonDraftWriter</h3>
+        <SampleCommonDraftWriter />
       </DraftContext>
     </div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
     ],
     "paths": {
       "@/api/*": ["./src/app/api/*"],
+      "@/components/*": ["./src/app/_components/*"],
+      "@/types/*": ["./src/app/_types/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
RichEdit に入れる Draft の形に対応した CommonDraftWriter を作成した。
今までの AI Agent はただの文字列を返してきたが、OpenAI の response_format にあらかじめ Draft の構造を渡しておくことで、フォーマットを駆使した返答を返してくる。

/sample ページの、CommonDraftWriter の場所で試用ができる。

![image](https://github.com/user-attachments/assets/d8a17818-00b5-4e23-ba5e-24f88499c761)

